### PR TITLE
Add support for Retina resolution with Firefox 18

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -61,5 +61,9 @@
 
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string> <!-- I have no good reference as to why this is 6.0 -->
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+    <key>NSPrincipalClass</key>
+    <string>GeckoNSApplication</string>
   </dict>
 </plist>


### PR DESCRIPTION
Firefox 18 added support for rendering the higher resolutions used with
Apples Retina displays. Copying these additional entries from Firefox's
Info.plist file enabled Retina support in Conkeror for me.
